### PR TITLE
Fix crash on HTC One M8

### DIFF
--- a/src/main/native/natj/CRuntime.cpp
+++ b/src/main/native/natj/CRuntime.cpp
@@ -885,7 +885,7 @@ void processStructureFunctions(JNIEnv* env, jclass type) {
   jobject libAnn =
       env->CallObjectMethod(type, gGetAnnotationMethod, gLibraryClass);
   if (!env->IsSameObject(libAnn, NULL)) {
-    jobject libName = env->CallObjectMethod(libAnn, gGetLibraryMethod);
+    jobject libName = env->CallObjectMethod(libAnn, gGetLibraryMethod, nullptr);
     env->DeleteLocalRef(libAnn);
     jstring libPath = (jstring)env->CallStaticObjectMethod(
         gNatJClass, gLookUpLibraryStaticMethod, libName, false);
@@ -957,7 +957,7 @@ void processStructureFunctions(JNIEnv* env, jclass type) {
       if (env->IsSameObject(var, NULL)) {
         info->variadic = kNotVariadic;
       } else {
-        info->variadic = env->CallByteMethod(var, gGetVariadicUnboxPolicyMethod);
+        info->variadic = env->CallByteMethod(var, gGetVariadicUnboxPolicyMethod, nullptr);
         if (info->variadic == gRuntimeVariadicPolicyValue) {
           info->variadic = gDefaultUnboxPolicy;
         } else if (info->variadic == gUnboxVariadicPolicyValue) {
@@ -1014,7 +1014,7 @@ void processStructureFunctions(JNIEnv* env, jclass type) {
 
       // Get method name
       jstring methodName =
-          (jstring)env->CallObjectMethod(fieldAnn, gGetCFunctionNameMethod);
+          (jstring)env->CallObjectMethod(fieldAnn, gGetCFunctionNameMethod, nullptr);
       if (env->GetStringUTFLength(methodName) == 0) {
         methodName =
             (jstring)env->CallObjectMethod(method, gGetMethodNameMethod);
@@ -1145,11 +1145,11 @@ void processStructureFunctions(JNIEnv* env, jclass type) {
 
       // Store whether it is a getter
       info->isGetter =
-          env->CallBooleanMethod(fieldAnn, gGetCVariableIsGetterMethod);
+          env->CallBooleanMethod(fieldAnn, gGetCVariableIsGetterMethod, nullptr);
 
       // Store the pointer of the variable
       jstring variableName =
-          (jstring)env->CallObjectMethod(fieldAnn, gGetCVariableNameMethod);
+          (jstring)env->CallObjectMethod(fieldAnn, gGetCVariableNameMethod, nullptr);
       if (env->GetStringUTFLength(variableName) == 0) {
         variableName =
             (jstring)env->CallObjectMethod(method, gGetMethodNameMethod);


### PR DESCRIPTION
There appears to be a bug on the HTC One M8, described here:

https://code.google.com/p/android/issues/detail?id=190058

Calls to methods on Annotations attempt to read parmaeters that
should not be there, resulting in "use of invalid jobject" error.
This affects libnatj.so, when NatJ.register() is called
the process crashes. Extract from log included below.

This bug looks like it is fixed in ASOP, but unfortunately
not in the HTC ROM (tested with the latest OTA ROM
available on this device, 6.12.161.4. Later firmware
versions are available from different carriers and for
manual download / install, I have not tested these).

The workaround described in the issue above prevents the crash.
This commit applies the workaround to CRuntime.cpp.

11-17 09:32:28.434 28187-28187/myapplication.dev A/art:
art/runtime/java_vm_ext.cc:448] JNI DETECTED ERROR IN APPLICATION: use
of invalid jobject 0xb38d2070
11-17 09:32:28.434 28187-28187/myapplication.dev A/art:
art/runtime/java_vm_ext.cc:448]     from void
org.moe.natj.c.CRuntime.registerClass(java.lang.Class)
...
11-17 09:32:28.435 28187-28187/myapplication.dev A/art:
art/runtime/java_vm_ext.cc:448]   native: #09 pc 0000acb1
/data/app/myapplication.dev-1/lib/arm/libnatj.so
(_JNIEnv::CallObjectMethod(_jobject*, _jmethodID*, ...)+28)
11-17 09:32:28.435 28187-28187/myapplication.dev A/art:
art/runtime/java_vm_ext.cc:448]   native: #10 pc 0000e0ef
/data/app/myapplication.dev-1/lib/arm/libnatj.so
(processStructureFunctions(_JNIEnv*, _jclass*)+814)