### PR TITLE
Support AVFoundation iOS 12.x again

### DIFF
--- a/src/main/java/org/moe/natj/general/NatJ.java
+++ b/src/main/java/org/moe/natj/general/NatJ.java
@@ -259,9 +259,7 @@ public class NatJ {
             }
 
             Library lann = type.getAnnotation(Library.class);
-            if (lann != null) {
-                lookUpLibrary(lann.value(), true);
-            }
+            lookUpLibrary(lann, true);
 
             NativeRuntime runtime = getRuntime(type, true);
             if (runtime != null) runtime.doRegistration(type);
@@ -425,6 +423,14 @@ public class NatJ {
         return darwinSystemFrameworkRootDir;
     }
 
+    protected static String lookUpLibrary(Library lann, boolean load) {
+        if (lann != null) {
+            return lookUpLibrary(lann.value(), load);
+        }
+
+        return null;
+    }
+
     /**
      * Looks up a library by its name in the file system.
      *
@@ -437,7 +443,7 @@ public class NatJ {
      *     library
      * @return The resolved path of the library
      */
-    protected static String lookUpLibrary(String name, boolean load) {
+    private static String lookUpLibrary(String name, boolean load) {
 
         synchronized (resolvedLibraries) {
             {

--- a/src/main/native/natj/CRuntime.cpp
+++ b/src/main/native/natj/CRuntime.cpp
@@ -882,14 +882,12 @@ void processStructureFunctions(JNIEnv* env, jclass type) {
 #endif
 
   // Load library if possible
-  jobject libAnn =
-      env->CallObjectMethod(type, gGetAnnotationMethod, gLibraryClass);
-  if (!env->IsSameObject(libAnn, NULL)) {
-    jobject libName = env->CallObjectMethod(libAnn, gGetLibraryMethod);
-    env->DeleteLocalRef(libAnn);
+  {
+    jobject libAnn =
+        env->CallObjectMethod(type, gGetAnnotationMethod, gLibraryClass);
     jstring libPath = (jstring)env->CallStaticObjectMethod(
-        gNatJClass, gLookUpLibraryStaticMethod, libName, false);
-    env->DeleteLocalRef(libName);
+        gNatJClass, gLookUpLibraryStaticMethod, libAnn, false);
+    env->DeleteLocalRef(libAnn);
     if (env->IsSameObject(libPath, NULL)) {
       libHandle = thisHandle;
     } else {
@@ -903,8 +901,6 @@ void processStructureFunctions(JNIEnv* env, jclass type) {
       env->ReleaseStringUTFChars(libPath, libCPath);
       env->DeleteLocalRef(libPath);
     }
-  } else {
-    libHandle = thisHandle;
   }
 
   // Get class methods elements

--- a/src/main/native/natj/NatJ.cpp
+++ b/src/main/native/natj/NatJ.cpp
@@ -123,7 +123,6 @@ jmethodID gIsDefaultMethodMethod = NULL;
 jmethodID gGetReturnTypeMethod = NULL;
 jmethodID gGetParameterTypesMethod = NULL;
 jmethodID gGetMethodNameMethod = NULL;
-jmethodID gGetLibraryMethod = NULL;
 jmethodID gLookUpLibraryStaticMethod = NULL;
 jmethodID gGetMethodDeclaringClassMethod = NULL;
 jmethodID gToNativeStaticMethod = NULL;
@@ -354,10 +353,8 @@ void JNICALL Java_org_moe_natj_general_NatJ_initialize(JNIEnv* env, jclass clazz
     LOGD << "Method 'boolean java.lang.reflect.Method.isDefault()' is not accessible.";
     env->ExceptionClear();
   }
-  gGetLibraryMethod =
-      env->GetMethodID(gLibraryClass, "value", "()Ljava/lang/String;");
   gLookUpLibraryStaticMethod = env->GetStaticMethodID(
-      gNatJClass, "lookUpLibrary", "(Ljava/lang/String;Z)Ljava/lang/String;");
+      gNatJClass, "lookUpLibrary", "(Lorg/moe/natj/general/ann/Library;Z)Ljava/lang/String;");
   gGetReturnTypeMethod =
       env->GetMethodID(gMethodClass, "getReturnType", "()Ljava/lang/Class;");
   gGetParameterTypesMethod = env->GetMethodID(gMethodClass, "getParameterTypes",

--- a/src/main/native/natj/NatJ.h
+++ b/src/main/native/natj/NatJ.h
@@ -511,7 +511,6 @@ extern jmethodID gIsDefaultMethodMethod;
 extern jmethodID gGetReturnTypeMethod;
 extern jmethodID gGetParameterTypesMethod;
 extern jmethodID gGetMethodNameMethod;
-extern jmethodID gGetLibraryMethod;
 extern jmethodID gLookUpLibraryStaticMethod;
 extern jmethodID gGetMethodDeclaringClassMethod;
 extern jmethodID gGetStructFieldOrderMethod;


### PR DESCRIPTION
The issue was brought up [here.](https://discuss.multi-os-engine.org/t/unsupported-ios-sdk-after-updating-to-moe-1-9-0/2922/2)
This is simple fallback code to support iOS 12.x.

Fixes https://github.com/multi-os-engine/multi-os-engine/issues/181
~~Note: This fallback doesn't work when using the AVFAudio class. For that the AVFoundation class needs to be still used.~~