### PR TITLE
Only create a ObjC Exception if the ObjCRuntime is initialised

### DIFF
--- a/src/main/native/natj/NatJ.h
+++ b/src/main/native/natj/NatJ.h
@@ -180,11 +180,14 @@ limitations under the License.
  * If ObjCRuntime is disabled, this does nothing.
  */
 #ifdef __APPLE__
-#define HANDLE_JAVA_EXCEPTION(env)                      \
-  jthrowable JAVA_EXC = env->ExceptionOccurred();       \
-  if (JAVA_EXC) {                                       \
-    JAVA_EXC = (jthrowable)env->NewGlobalRef(JAVA_EXC); \
-    env->ExceptionClear();                              \
+#define HANDLE_JAVA_EXCEPTION(env)                          \
+  jthrowable JAVA_EXC = NULL;                               \
+  if (hasObjCRuntimeBeenInitialized()) {                    \
+       JAVA_EXC = env->ExceptionOccurred();                 \
+      if (JAVA_EXC) {                                       \
+        JAVA_EXC = (jthrowable)env->NewGlobalRef(JAVA_EXC); \
+        env->ExceptionClear();                              \
+      }                                                     \
   }
 #else
 #define HANDLE_JAVA_EXCEPTION(env) jthrowable JAVA_EXC = NULL


### PR DESCRIPTION
Fixes https://github.com/multi-os-engine/multi-os-engine/issues/172