### PR TITLE
Try finding out the correct framework dir on simulator

### DIFF
--- a/src/main/java/org/moe/natj/general/NatJ.java
+++ b/src/main/java/org/moe/natj/general/NatJ.java
@@ -402,6 +402,29 @@ public class NatJ {
      */
     private static Map<String, String> resolvedLibraries = new HashMap<String, String>();
 
+
+    private static String darwinSystemFrameworkRootDir = null;
+
+    private static String getDarwinSystemFrameworkRootDir() {
+        if (darwinSystemFrameworkRootDir == null) {
+            String simulatorFrameworkPath = getSimulatorFrameworkPath();
+            if (simulatorFrameworkPath == null || simulatorFrameworkPath.isEmpty()) {
+                darwinSystemFrameworkRootDir = "/System/Library/Frameworks/";
+            } else {
+                int index = simulatorFrameworkPath.indexOf("CoreFoundation.framework");
+                if (index < 0) {
+                    // Not good
+                    System.err.println("Error: Unexpected framework path: " + simulatorFrameworkPath);
+                    darwinSystemFrameworkRootDir = "/System/Library/Frameworks/";
+                } else {
+                    darwinSystemFrameworkRootDir = simulatorFrameworkPath.substring(0, index);
+                }
+            }
+        }
+
+        return darwinSystemFrameworkRootDir;
+    }
+
     /**
      * Looks up a library by its name in the file system.
      *
@@ -478,7 +501,7 @@ public class NatJ {
 
             if (isDarwin()) {
                 for (String path : new String[] {
-                        "/System/Library/Frameworks/" + name + ".framework"
+                    getDarwinSystemFrameworkRootDir() + name + ".framework"
                 }) {
                     String exec_path = path + "/" + name;
                     File file = new File(path);
@@ -1182,4 +1205,11 @@ public class NatJ {
      * all other cases
      */
     public static native boolean loadFramework(String path);
+
+    /**
+     * Get the runtime system framework path on simulator.
+     *
+     * @return The path to the CoreFoundation.framework if running on simulator, or NULL on read device.
+     */
+    private static native String getSimulatorFrameworkPath();
 }

--- a/src/main/native/natj/NatJ.cpp
+++ b/src/main/native/natj/NatJ.cpp
@@ -578,6 +578,27 @@ jstring JNICALL Java_org_moe_natj_general_NatJ_getPlatformName(JNIEnv* env,
   return env->NewStringUTF(NATJ_PLATFORM);
 }
 
+jstring JNICALL Java_org_moe_natj_general_NatJ_getSimulatorFrameworkPath(JNIEnv* env,
+                                                                         jclass clazz) {
+  
+#ifdef __APPLE__
+#if TARGET_OS_SIMULATOR
+  Dl_info di;
+  int ret = dladdr((const void *)CFArrayContainsValue, &di);
+  if (!ret) {
+      LOGF << "Failed to get framework path!";
+  }
+  return env->NewStringUTF(di.dli_fname);
+#else
+  // Only for simulator builds
+  return NULL;
+#endif
+#else
+  // Only for Darwin systems
+  return NULL;
+#endif
+}
+
 jboolean JNICALL Java_org_moe_natj_general_NatJ_loadFramework(JNIEnv* env,
                                                                  jclass clazz,
                                                                  jstring path) {
@@ -593,7 +614,6 @@ jboolean JNICALL Java_org_moe_natj_general_NatJ_loadFramework(JNIEnv* env,
   return false;
 #endif
 }
-
 
 void handleShutdown(JNIEnv* env) { gJVMIsRunning = false; }
 

--- a/src/main/native/natj/NatJ.h
+++ b/src/main/native/natj/NatJ.h
@@ -94,6 +94,8 @@ limitations under the License.
 /** @} */
 
 #ifdef __APPLE__
+#import <CoreFoundation/CoreFoundation.h>
+
 #import <TargetConditionals.h>
 #if TARGET_OS_IOS
 #define NATJ_PLATFORM "ios"
@@ -377,6 +379,17 @@ JNIEXPORT void JNICALL
 JNIEXPORT jstring JNICALL
     Java_org_moe_natj_general_NatJ_getPlatformName(JNIEnv* env,
                                                        jclass clazz);
+
+/**
+ * Get the runtime system framework path on simulator.
+ *
+ * @param env JNIEnv pointer for the current thread
+ * @param clazz Java class of NatJ, used for nothing
+ * @return The path to the CoreFoundation.framework if running on simulator, or NULL on read device.
+ */
+JNIEXPORT jstring JNICALL
+    Java_org_moe_natj_general_NatJ_getSimulatorFrameworkPath(JNIEnv* env,
+                                                             jclass clazz);
 
 /**
  * Try to load framework.


### PR DESCRIPTION
To find out the correct framework directory on simulator, it uses `dladdr` to get the path of the loaded module that contains the `CFArrayContainsValue` symbol, which is the CoreFoundation.framework, thus we could know the actual directory that contains the frameworks.